### PR TITLE
Dockerize 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,11 @@
 sudo: false  # http://docs.travis-ci.com/user/migrating-from-legacy/
 language: python
 python:
-  - 2.7
-  - 3.3
-  - 3.4
   - 3.5
 install: pip install -r requirements/dev.txt
-before_script: flask lint
-script: flask test
+services:
+  - docker
+before_install:
+  - docker build -t mrr_website .
+  - docker run -d -p 8080:8080  mrr_website
+script: sleep 10 && curl -iv  localhost:8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y python3 python3-pip nodejs npm git
+RUN ln -s /usr/bin/nodejs /usr/bin/node
+
+RUN pip3 install --upgrade pip && pip install gunicorn
+
+ADD ./mrr_website /app/mrr_website
+ADD ./requirements /app/requirements
+ADD requirements.txt /app
+ADD autoapp.py /app
+ADD bower.json /app
+ADD .bowerrc /app
+
+WORKDIR /app
+
+
+RUN pip3 install -r requirements.txt
+
+RUN npm install -g bower
+RUN bower --allow-root install
+  
+CMD ["gunicorn", "-w4", "-b 0.0.0.0:8080", "autoapp:app"]


### PR DESCRIPTION
Creates a Dockerfile to build the app as a single docker image. This should make deployments to either DigitalOcean or Heroku or similar easier, as we can just deploy the app as a docker image. I've  standardised us on Python 3.5 and updated the travis.ci file so that it builds the Docker image and then checks that it gets a response from the server. 