### PR TITLE
Deploy using Heroku

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-# Config file for automatic testing at travis-ci.org
-sudo: false  # http://docs.travis-ci.com/user/migrating-from-legacy/
+sudo: false
 language: python
 python:
   - 3.5
@@ -7,6 +6,10 @@ install: pip install -r requirements/dev.txt
 services:
   - docker
 before_install:
-  - docker build -t mrr_website .
-  - docker run -d -p 8080:8080  mrr_website
-script: sleep 10 && curl -iv  localhost:8080
+  - docker build -t registry.heroku.com/$STAGING_APP/web .
+  - docker run -d -p 8080:8080 -e PORT=8080  registry.heroku.com/$STAGING_APP/web
+after_success:
+  - .travis/after_success.sh
+branches:
+  only:
+      - master

--- a/.travis/after_success.sh
+++ b/.travis/after_success.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+if [ $TRAVIS_PULL_REQUEST != "false" -o $TRAVIS_BRANCH != "master" ]
+then
+    echo "Skipping deployment on branch=$TRAVIS_BRANCH, PR=$TRAVIS_PULL_REQUEST"
+    exit 0;
+fi
+
+docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" registry.heroku.com
+docker push registry.heroku.com/$STAGING_APP/web

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ADD ./requirements /app/requirements
 ADD requirements.txt /app
 ADD autoapp.py /app
 ADD bower.json /app
+ADD start-in-docker.sh /app
 ADD .bowerrc /app
 
 WORKDIR /app
@@ -20,4 +21,4 @@ RUN pip3 install -r requirements.txt
 RUN npm install -g bower
 RUN bower --allow-root install
   
-CMD ["gunicorn", "-w4", "-b 0.0.0.0:8080", "autoapp:app"]
+CMD ["/app/start-in-docker.sh"]

--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,17 @@ To run all tests, run ::
 
     flask test
 
+Deploying to Heroku
+-------------
+
+Deploys to Heroku are automated through travis ci. Three environment variables are required in your travis ci configuration to deploy:
+
+$STAGING_APP - The app name in Heroku 
+$DOCKER_USERNAME - Your Heroku username (email address)
+$DOCKER_PASSWORD - Your Heroku API key, accessable in https://dashboard.heroku.com/account
+
+The application is packaged as a docker image and is pushed to Herkou's docker repository. See .travis/after_success.sh
+
 
 Migrations
 ----------

--- a/mrr_website/templates/public/home.html
+++ b/mrr_website/templates/public/home.html
@@ -6,7 +6,7 @@
 
   <h1>Welcome to MRR Website</h1>
 
-  <p>This is a starter Flask template. It includes Bootstrap 3, jQuery 2, Flask-SQLAlchemy, WTForms, and various testing utilities out of the box.</p>
+  <p>This app has been deployed from Travis!</p>
   <p><a href="https://github.com/sloria/cookiecutter-flask" class="btn btn-primary btn-large">Learn more &raquo;</a></p>
 </div><!-- /.jumbotron -->
 

--- a/start-in-docker.sh
+++ b/start-in-docker.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+gunicorn -w4 -b 0.0.0.0:$PORT autoapp:app


### PR DESCRIPTION
This is all the setup which is required to setup a CI pipeline to deploy to Heroku. We already have travis ci setup, this extends it to push the docker image to heroku's doker repository where it can be run. 